### PR TITLE
Switch to pip install for PuppetBoard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'onceover'
+# https://github.com/dylanratcliffe/onceover/pull/331
+gem 'onceover', git: 'https://github.com/smortex/onceover.git', branch: 'fix-rspec-puppet-4'
 gem 'onceover-codequality'
 gem 'rubocop'

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,10 +6,8 @@ mod 'puppetlabs-stdlib', '9.4.1'
 mod 'puppetlabs-cron_core',    '1.2.1'
 mod 'puppetlabs-sshkeys_core', '2.4.0'
 
-# mod 'puppet-puppetboard', '9.0.0'
-# https://github.com/voxpupuli/puppet-puppetboard/pull/368
-mod 'puppetboard', git: 'https://github.com/voxpupuli/puppet-puppetboard.git',
-                   ref: '8d9cfb70fe49c40afa34e3d7fb16bb7872b70c7e'
+mod 'puppet-python', '7.3.0'
+mod 'puppet-puppetboard', '10.0.0'
 
 mod 'choria-choria',                        '0.30.3'
 mod 'choria-mcollective',                   '0.14.4'

--- a/site-modules/profile/manifests/puppetboard.pp
+++ b/site-modules/profile/manifests/puppetboard.pp
@@ -4,7 +4,13 @@
 class profile::puppetboard (
   Stdlib::Port $port = 8000,
 ) {
+  include profile::python
+
   class { 'puppetboard':
+    install_from        => 'pip',
+    python_version      => '3.9',
+    basedir             => '/usr/local/www/puppetboard',
+    secret_key          => stdlib::fqdn_rand_string(32),
     puppetdb_host       => 'puppetdb.lan',
     puppetdb_port       => 8081,
     puppetdb_cert       => '/usr/local/www/puppetboard/ssl/puppetdb_client_cert.pem',
@@ -44,6 +50,27 @@ class profile::puppetboard (
     source => "/var/puppet/ssl/private_keys/${fact('networking.fqdn')}.pem",
   }
 
+  file { '/usr/local/www/puppetboard/wsgi.py':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    content => @(WSGI),
+      from __future__ import absolute_import
+      import os
+      import logging
+
+      logging.basicConfig(filename='/tmp/puppetboard.log', level=logging.DEBUG)
+
+      os.environ['PUPPETBOARD_SETTINGS'] = '/usr/local/etc/puppetboard/settings.py'
+
+      try:
+          from puppetboard.app import app as application  # noqa: F401
+      except Exception as inst:
+          logging.exception("Error: %s", str(type(inst)))
+      | WSGI
+    notify  => Service['puppetboard'],
+  }
+
   package { 'uwsgi-py39':
     ensure => installed,
   }
@@ -61,6 +88,7 @@ class profile::puppetboard (
     group   => 'wheel',
     mode    => '0755',
     content => epp('profile/puppetboard/puppetboard.rc.epp'),
+    notify  => Service['puppetboard'],
   }
 
   service { 'puppetboard':

--- a/site-modules/profile/manifests/python.pp
+++ b/site-modules/profile/manifests/python.pp
@@ -1,0 +1,7 @@
+# @summary Manage Python
+class profile::python {
+  class { 'python':
+    version => '39',
+    dev     => 'present',
+  }
+}

--- a/site-modules/profile/templates/puppetboard/puppetboard.rc.epp
+++ b/site-modules/profile/templates/puppetboard/puppetboard.rc.epp
@@ -13,7 +13,7 @@ load_rc_config "$name"
 
 : ${puppetboard_enable="NO"}
 : ${puppetboard_user="puppetboard"}
-: ${puppetboard_options="--http :<%= $profile::puppetboard::port %> --wsgi-file /usr/local/www/puppetboard/wsgi.py"}
+: ${puppetboard_options="--http :<%= $profile::puppetboard::port %> --venv /usr/local/www/puppetboard/virtenv-puppetboard/ --wsgi-file /usr/local/www/puppetboard/wsgi.py"}
 
 command=/usr/local/bin/uwsgi
 command_args="--master --daemonize ${pidfile} --die-on-term --pidfile ${pidfile} ${puppetboard_options}"


### PR DESCRIPTION
Maintaining the package in FreeBSD is a PITA due to the many dependenciens and the way the project depend on old dependencies.

Switch to pip to manage it.