### PR TITLE
Add support for OpenVox packages testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         ruby:
           - "3.1"
           - "3.2"
+          - "3.3"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,9 @@ mod 'choria-choria',                        '0.31.0'
 mod 'choria-mcollective',                   '0.14.6'
 # mod 'choria-mcollective_agent_bolt_tasks',  '0.22.0'
 # https://github.com/choria-plugins/tasks-agent/pull/20
-mod 'choria-mcollective_agent_bolt_tasks', git: 'https://github.com/choria-plugins/tasks-agent', ref: '60d5ce5f15b4dbcbe068f875bc989e94d5121c32'
+mod 'choria-mcollective_agent_bolt_tasks',
+    git: 'https://github.com/choria-plugins/tasks-agent',
+    ref: '60d5ce5f15b4dbcbe068f875bc989e94d5121c32'
 mod 'choria-mcollective_agent_filemgr',     '2.1.0'
 mod 'choria-mcollective_agent_nettest',     '4.1.0'
 mod 'choria-mcollective_agent_package',     '5.5.1'

--- a/bin/build-openvox-infrastructure.sh
+++ b/bin/build-openvox-infrastructure.sh
@@ -38,8 +38,8 @@ bastille clone $TEMPLATE $JAIL 10.0.0.10
 bastille start $JAIL
 bastille cmd $JAIL hostname $JAIL.lan
 bastille pkg $JAIL install -y openvox-agent${puppet_version} openvox-server${puppet_version} openvoxdb-terminus${puppet_version}
-bastille cmd $JAIL puppet apply < manifests/common.pp
-bastille cmd $JAIL puppet apply < manifests/puppetserver.pp
+jexec $JAIL puppet apply < manifests/common.pp
+jexec $JAIL puppet apply < manifests/puppetserver.pp
 bastille cmd $JAIL service puppetserver restart
 
 JAIL=puppetdb
@@ -48,7 +48,7 @@ bastille config $JAIL set allow.raw_sockets 1
 bastille config $JAIL set allow.sysvipc 1
 bastille start $JAIL
 bastille pkg $JAIL install -y openvox-agent${puppet_version} openvoxdb${puppet_version} postgresql${postgresql_version}-server postgresql${postgresql_version}-contrib postgresql${postgresql_version}-client sudo icu
-bastille cmd $JAIL puppet apply < manifests/common.pp
+jexec $JAIL puppet apply < manifests/common.pp
 bastille sysrc $JAIL postgresql_enable=yes
 bastille cmd $JAIL service postgresql initdb
 bastille cmd $JAIL service postgresql start
@@ -74,17 +74,17 @@ bastille cmd $JAIL puppetdb ssl-setup
 bastille sysrc $JAIL puppetdb_enable=yes
 bastille cmd $JAIL service puppetdb start
 
-bastille cmd puppet tee /usr/local/etc/puppet/puppetdb.conf << EOT
+jexec puppet tee /usr/local/etc/puppet/puppetdb.conf << EOT
 [main]
 server_urls = https://puppetdb.lan:8081
 EOT
-bastille cmd puppet tee /usr/local/etc/puppet/puppet.conf << EOT
+jexec puppet tee /usr/local/etc/puppet/puppet.conf << EOT
 [master]
   storeconfigs = true
   storeconfigs_backend = puppetdb
   reports = puppetdb
 EOT
-bastille cmd puppet tee /usr/local/etc/puppet/routes.yaml << EOT
+jexec puppet tee /usr/local/etc/puppet/routes.yaml << EOT
 ---
 master:
   facts:
@@ -98,7 +98,7 @@ JAIL=puppetboard
 bastille clone $TEMPLATE $JAIL 10.0.0.12
 bastille start $JAIL
 bastille pkg $JAIL install -y openvox-agent${puppet_version}
-bastille cmd $JAIL puppet apply < manifests/common.pp
+jexec $JAIL puppet apply < manifests/common.pp
 bastille cmd $JAIL sh -c 'puppet agent -t || :'
 
 JAIL=node1
@@ -107,21 +107,21 @@ bastille config $JAIL set allow.raw_sockets 1
 bastille config $JAIL set allow.sysvipc 1
 bastille start $JAIL
 bastille pkg $JAIL install -y openvox-agent${puppet_version}
-bastille cmd $JAIL puppet apply < manifests/common.pp
+jexec $JAIL puppet apply < manifests/common.pp
 bastille cmd $JAIL sh -c 'puppet agent -t || :'
 
 JAIL=node2
 bastille clone  $TEMPLATE $JAIL 10.0.0.101
 bastille start $JAIL
 bastille pkg $JAIL install -y openvox-agent${puppet_version}
-bastille cmd $JAIL puppet apply < manifests/common.pp
+jexec $JAIL puppet apply < manifests/common.pp
 bastille cmd $JAIL sh -c 'puppet agent -t || :'
 
 bastille cmd 'puppet' puppetserver ca sign --all
 
-bastille cmd 'puppet' sh -c 'puppet apply --detailed-exitcodes; if [ $? -ne 2 ]; then echo "Failed to apply catalog"; exit 1; fi' < manifests/r10k.pp
+jexec 'puppet' sh -c 'puppet apply --detailed-exitcodes; if [ $? -ne 2 ]; then echo "Failed to apply catalog"; exit 1; fi' < manifests/r10k.pp
 
 for node in puppet puppetdb puppetboard node1 node2; do
 	bastille cmd $node sh -c 'puppet agent --test --detailed-exitcodes; if [ $? -ne 0 -a $? -ne 2 ]; then echo "Failed to apply catalog"; exit 1; fi'
-	bastille cmd $node puppet apply < manifests/puppet.pp
+	jexec $node puppet apply < manifests/puppet.pp
 done

--- a/bin/build-openvox-infrastructure.sh
+++ b/bin/build-openvox-infrastructure.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+
+postgresql_version=17
+
+if [ $# -ne 2 ]; then
+  cat << EOT >&2
+usage: $0 template puppet-version
+EOT
+  exit 1
+fi
+
+wait_for_puppetserver()
+{
+  set +x
+  printf "Waiting for OpenvoxServer to be ready"
+  try=0
+  while ! nc -z 10.0.0.10 8140; do
+    try=$((try + 1))
+    if [ $try -eq 60 ]; then
+      echo
+      echo "Timeout reached while waiting for OpenvoxServer to be ready" >&2
+      exit 1
+    fi
+    printf "."
+    sleep 1
+  done
+  echo
+  set -x
+}
+
+TEMPLATE="$1"
+puppet_version="$2"
+
+set -ex
+
+JAIL=puppet
+bastille clone $TEMPLATE $JAIL 10.0.0.10
+bastille start $JAIL
+bastille cmd $JAIL hostname $JAIL.lan
+bastille pkg $JAIL install -y openvox-agent${puppet_version} openvox-server${puppet_version} openvoxdb-terminus${puppet_version}
+bastille cmd $JAIL puppet apply < manifests/common.pp
+bastille cmd $JAIL puppet apply < manifests/puppetserver.pp
+bastille cmd $JAIL service puppetserver restart
+
+JAIL=puppetdb
+bastille clone $TEMPLATE $JAIL 10.0.0.11
+bastille config $JAIL set allow.raw_sockets 1
+bastille config $JAIL set allow.sysvipc 1
+bastille start $JAIL
+bastille pkg $JAIL install -y openvox-agent${puppet_version} openvoxdb${puppet_version} postgresql${postgresql_version}-server postgresql${postgresql_version}-contrib postgresql${postgresql_version}-client sudo icu
+bastille cmd $JAIL puppet apply < manifests/common.pp
+bastille sysrc $JAIL postgresql_enable=yes
+bastille cmd $JAIL service postgresql initdb
+bastille cmd $JAIL service postgresql start
+bastille cmd $JAIL sh -c "echo \"CREATE ROLE puppetdb LOGIN ENCRYPTED PASSWORD 'puppetdb'\" | sudo -u postgres psql"
+bastille cmd $JAIL sh -c "echo \"CREATE DATABASE puppetdb OWNER puppetdb\" | sudo -u postgres psql"
+bastille cmd $JAIL sh -c "echo \"CREATE EXTENSION pg_trgm;\" | sudo -u postgres psql puppetdb"
+bastille cmd $JAIL sh -c "echo \"host    all             all             10.0.0.11/32        md5\" >> /var/db/postgres/data${postgresql_version}/pg_hba.conf"
+bastille cmd $JAIL sh -c "sed -i '' -e \"s/#listen_addresses = '[^']*'/listen_addresses = '*'/\" /var/db/postgres/data${postgresql_version}/postgresql.conf"
+bastille cmd $JAIL sh -c 'service postgresql restart'
+
+bastille cmd $JAIL sh -c 'echo "subname = //10.0.0.11:5432/puppetdb" >> /usr/local/etc/puppetdb/conf.d/database.ini'
+bastille cmd $JAIL sh -c 'echo "username = puppetdb" >> /usr/local/etc/puppetdb/conf.d/database.ini'
+bastille cmd $JAIL sh -c 'echo "password = puppetdb" >> /usr/local/etc/puppetdb/conf.d/database.ini'
+wait_for_puppetserver
+bastille cmd $JAIL sh -c 'puppet agent -t || :'
+if [ $puppet_version -eq 5 ]; then
+  bastille cmd puppet puppet cert sign --all
+else
+  bastille cmd puppet puppetserver ca sign --all
+fi
+bastille cmd $JAIL sh -c 'puppet agent -t || :'
+bastille cmd $JAIL puppetdb ssl-setup
+bastille sysrc $JAIL puppetdb_enable=yes
+bastille cmd $JAIL service puppetdb start
+
+bastille cmd puppet tee /usr/local/etc/puppet/puppetdb.conf << EOT
+[main]
+server_urls = https://puppetdb.lan:8081
+EOT
+bastille cmd puppet tee /usr/local/etc/puppet/puppet.conf << EOT
+[master]
+  storeconfigs = true
+  storeconfigs_backend = puppetdb
+  reports = puppetdb
+EOT
+bastille cmd puppet tee /usr/local/etc/puppet/routes.yaml << EOT
+---
+master:
+  facts:
+    terminus: puppetdb
+    cache: yaml
+EOT
+bastille cmd puppet service puppetserver restart
+wait_for_puppetserver
+
+JAIL=puppetboard
+bastille clone $TEMPLATE $JAIL 10.0.0.12
+bastille start $JAIL
+bastille pkg $JAIL install -y openvox-agent${puppet_version}
+bastille cmd $JAIL puppet apply < manifests/common.pp
+bastille cmd $JAIL sh -c 'puppet agent -t || :'
+
+JAIL=node1
+bastille clone $TEMPLATE $JAIL 10.0.0.100
+bastille config $JAIL set allow.raw_sockets 1
+bastille config $JAIL set allow.sysvipc 1
+bastille start $JAIL
+bastille pkg $JAIL install -y openvox-agent${puppet_version}
+bastille cmd $JAIL puppet apply < manifests/common.pp
+bastille cmd $JAIL sh -c 'puppet agent -t || :'
+
+JAIL=node2
+bastille clone  $TEMPLATE $JAIL 10.0.0.101
+bastille start $JAIL
+bastille pkg $JAIL install -y openvox-agent${puppet_version}
+bastille cmd $JAIL puppet apply < manifests/common.pp
+bastille cmd $JAIL sh -c 'puppet agent -t || :'
+
+bastille cmd 'puppet' puppetserver ca sign --all
+
+bastille cmd 'puppet' sh -c 'puppet apply --detailed-exitcodes; if [ $? -ne 2 ]; then echo "Failed to apply catalog"; exit 1; fi' < manifests/r10k.pp
+
+for node in puppet puppetdb puppetboard node1 node2; do
+	bastille cmd $node sh -c 'puppet agent --test --detailed-exitcodes; if [ $? -ne 0 -a $? -ne 2 ]; then echo "Failed to apply catalog"; exit 1; fi'
+	bastille cmd $node puppet apply < manifests/puppet.pp
+done

--- a/bin/destroy-puppet-infrastructure.sh
+++ b/bin/destroy-puppet-infrastructure.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-bastille destroy --auto puppet
-bastille destroy --auto puppetdb
-bastille destroy --auto puppetboard
-bastille destroy --auto node1
-bastille destroy --auto node2
+bastille destroy --auto --yes puppet
+bastille destroy --auto --yes puppetdb
+bastille destroy --auto --yes puppetboard
+bastille destroy --auto --yes node1
+bastille destroy --auto --yes node2

--- a/bin/template-update.sh
+++ b/bin/template-update.sh
@@ -41,9 +41,7 @@ bastille start $TEMPLATE_NAME
 if [ $interactive -eq 1 ]; then
   bastille console $TEMPLATE_NAME
 else
-  bastille cmd $TEMPLATE_NAME pkg update
-  bastille cmd $TEMPLATE_NAME pkg upgrade -y
-  bastille cmd $TEMPLATE_NAME pkg fetch -yd puppet7 puppet8 puppetserver7 puppetserver8 puppetdb7 puppetdb8 puppetdb-terminus7 puppetdb-terminus8 postgresql16-server postgresql16-contrib git-lite rubygem-r10k choria rubygem-choria-mcorpc-support rubygem-net-ping uwsgi-py311
+  bastille template $TEMPLATE_NAME templates/base
 fi
 
 bastille stop $TEMPLATE_NAME

--- a/bin/templates/base/Bastillefile
+++ b/bin/templates/base/Bastillefile
@@ -1,4 +1,5 @@
 CMD mkdir -p /usr/local/etc/pkg/repos/
 CP FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
 PKG ca_root_nss
-CMD pkg fetch -yd puppet7 puppet8 puppetserver7 puppetserver8 puppetdb7 puppetdb8 puppetdb-terminus7 puppetdb-terminus8 postgresql16-server postgresql16-contrib git-lite rubygem-r10k choria rubygem-choria-mcorpc-support rubygem-net-ping uwsgi-py311
+CMD pkg upgrade -y
+CMD pkg fetch -yd openvox-agent8 openvox-server8 openvoxdb8 openvoxdb-terminus8 puppet8 puppetserver8 puppetdb8 puppetdb-terminus8 postgresql17-server postgresql17-contrib git-lite rubygem-r10k choria rubygem-choria-mcorpc-support rubygem-net-ping uwsgi-py311

--- a/site-modules/profile/manifests/puppetboard.pp
+++ b/site-modules/profile/manifests/puppetboard.pp
@@ -65,7 +65,7 @@ class profile::puppetboard (
 
   class { 'puppetboard':
     install_from        => 'pip',
-    python_version      => '3.11',
+    python_version      => "${profile::python::major}.${profile::python::minor}",
     basedir             => '/usr/local/www/puppetboard',
     secret_key          => stdlib::fqdn_rand_string(32),
     puppetdb_host       => 'puppetdb.lan',
@@ -98,7 +98,7 @@ class profile::puppetboard (
     notify  => Service['puppetboard'],
   }
 
-  package { 'uwsgi-py311':
+  package { "uwsgi-py${profile::python::major}${profile::python::minor}":
     ensure => installed,
   }
 

--- a/site-modules/profile/manifests/python.pp
+++ b/site-modules/profile/manifests/python.pp
@@ -1,7 +1,10 @@
 # @summary Manage Python
-class profile::python {
+class profile::python (
+  Integer[0] $major = 3,
+  Integer[0] $minor = 11,
+) {
   class { 'python':
-    version => '311',
+    version => "${major}${minor}",
     dev     => 'present',
   }
 }


### PR DESCRIPTION
CI still run with Puppet for now, as we rely on onceover which his currently tied to it.

This PR allows to run acceptance tests on FreeBSD with either the legacy Puppet packages or the new OpenVox ones.