### PR TITLE
Relocate puppetboard files

### DIFF
--- a/site-modules/profile/manifests/puppetboard.pp
+++ b/site-modules/profile/manifests/puppetboard.pp
@@ -4,78 +4,62 @@
 class profile::puppetboard (
   Stdlib::Port $port = 8000,
 ) {
-  include profile::python
+  $python_version = '311'
 
   file {
     default:
+      ensure => directory,
       owner  => 'root',
       group  => 'wheel',
+      mode   => '0755',
       before => Service['puppetboard'],
       ;
-    '/usr/local/etc/puppetboard':
-      ensure => directory,
-      mode   => '0755',
+    '/usr/local/etc/puppetboard/ssl':
       ;
-    '/usr/local/www':
-      ensure => directory,
-      group  => 'puppetboard',
-      mode   => '0755',
-      ;
-    '/usr/local/www/puppetboard/ssl':
-      ensure => directory,
-      mode   => '0755',
-      ;
-    '/usr/local/www/puppetboard/ssl/ca.pem':
+    '/usr/local/etc/puppetboard/ssl/ca.pem':
       ensure => file,
-      group  => 'wheel',
       mode   => '0644',
       source => '/var/puppet/ssl/certs/ca.pem',
       ;
-    '/usr/local/www/puppetboard/ssl/puppetdb_client_cert.pem':
+    '/usr/local/etc/puppetboard/ssl/puppetdb_client_cert.pem':
       ensure => file,
-      group  => 'wheel',
       mode   => '0644',
       source => "/var/puppet/ssl/certs/${fact('networking.fqdn')}.pem",
       ;
-    '/usr/local/www/puppetboard/ssl/puppetdb_client_key.pem':
+    '/usr/local/etc/puppetboard/ssl/puppetdb_client_key.pem':
       ensure => file,
       group  => 'puppetboard',
       mode   => '0640',
       source => "/var/puppet/ssl/private_keys/${fact('networking.fqdn')}.pem",
       ;
     '/var/log/puppetboard':
-      ensure => directory,
-      owner  => 'puppetboard',
-      group  => 'puppetboard',
-      mode   => '0755',
+      owner => 'puppetboard',
+      group => 'puppetboard',
       ;
     '/var/run/puppetboard':
-      ensure => directory,
-      owner  => 'puppetboard',
-      group  => 'puppetboard',
-      mode   => '0755',
+      owner => 'puppetboard',
+      group => 'puppetboard',
       ;
     '/usr/local/etc/rc.d/puppetboard':
       ensure  => file,
-      group   => 'wheel',
       mode    => '0755',
       content => epp('profile/puppetboard/puppetboard.rc.epp'),
       ;
   }
 
   class { 'puppetboard':
-    package_name        => 'py311-puppetboard',
+    package_name        => "py${python_version}-puppetboard",
     secret_key          => stdlib::fqdn_rand_string(32),
     puppetdb_host       => 'puppetdb.lan',
     puppetdb_port       => 8081,
-    puppetdb_cert       => '/usr/local/www/puppetboard/ssl/puppetdb_client_cert.pem',
-    puppetdb_key        => '/usr/local/www/puppetboard/ssl/puppetdb_client_key.pem',
-    puppetdb_ssl_verify => '/usr/local/www/puppetboard/ssl/ca.pem',
+    puppetdb_cert       => '/usr/local/etc/puppetboard/ssl/puppetdb_client_cert.pem',
+    puppetdb_key        => '/usr/local/etc/puppetboard/ssl/puppetdb_client_key.pem',
+    puppetdb_ssl_verify => '/usr/local/etc/puppetboard/ssl/ca.pem',
     offline_mode        => true,
     notify              => Service['puppetboard'],
   }
 
-  package { "uwsgi-py${profile::python::major}${profile::python::minor}":
+  package { "uwsgi-py${python_version}":
     ensure => installed,
   }
 


### PR DESCRIPTION
Since we now install the package again, put the ssl certificates next to the configuration file.  Also rework files resources to remove duplication.